### PR TITLE
Fix build with musl libc

### DIFF
--- a/mtdev2tuio.c
+++ b/mtdev2tuio.c
@@ -41,6 +41,7 @@
 #include <getopt.h>
 #include <signal.h>
 #include <sys/utsname.h>
+#include <sys/file.h>
 
 #define NSEC_PER_USEC   1000L
 #define NSEC_PER_SEC    1000000000L


### PR DESCRIPTION
Include missing header to prevent build error detected by buildroot:
http://autobuild.buildroot.net/results/aee/aee411047265bf205f8990a3d0d2310decb5fd19/build-end.log

Signed-off-by: Bernd Kuhls bernd.kuhls@t-online.de
