### PR TITLE
implicit declaration of flock in mtdev2tuio.c

### DIFF
--- a/mtdev2tuio.c
+++ b/mtdev2tuio.c
@@ -41,6 +41,7 @@
 #include <getopt.h>
 #include <signal.h>
 #include <sys/utsname.h>
+#include <sys/file.h>
 
 #define NSEC_PER_USEC   1000L
 #define NSEC_PER_SEC    1000000000L


### PR DESCRIPTION
I received an error when compiling on ubuntu 16.04.. Adding #include <sys/file.h> fixed the issue.

#7 